### PR TITLE
Add git to be able to use repositories in Kustomize

### DIFF
--- a/Amazon/Dockerfile
+++ b/Amazon/Dockerfile
@@ -20,6 +20,7 @@ RUN apk add --update --no-cache \
         python3 \
         python3-dev \
         py3-pip \
+        git \
     && wget -q https://storage.googleapis.com/kubernetes-helm/helm-${HELM_VERSION}-linux-amd64.tar.gz -O - | tar -xzO linux-amd64/helm > /usr/local/bin/helm \
     && pip3 install awscli --upgrade \
     && curl -LO https://storage.googleapis.com/kubernetes-release/release/`curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt`/bin/linux/amd64/kubectl \

--- a/Azure/Dockerfile
+++ b/Azure/Dockerfile
@@ -22,6 +22,7 @@ RUN apk add --update --no-cache \
         python3 \
         python3-dev \
         py3-pip \
+        git \
     && wget -q https://storage.googleapis.com/kubernetes-helm/helm-${HELM_VERSION}-linux-amd64.tar.gz -O - | tar -xzO linux-amd64/helm > /usr/local/bin/helm \
     && pip3 install azure-cli --upgrade \
     && apk del gcc libffi-dev openssl-dev \

--- a/DigitalOcean/Dockerfile
+++ b/DigitalOcean/Dockerfile
@@ -15,6 +15,7 @@ RUN apk add --update --no-cache \
         gettext \
         make \
         jq \
+        git \
     && wget -q https://storage.googleapis.com/kubernetes-helm/helm-${HELM_VERSION}-linux-amd64.tar.gz -O - | tar -xzO linux-amd64/helm > /usr/local/bin/helm \
     && wget -q https://github.com/digitalocean/doctl/releases/download/v1.35.0/doctl-1.35.0-linux-amd64.tar.gz -O - | tar -xzO doctl > /usr/local/bin/doctl \
     && curl -LO https://storage.googleapis.com/kubernetes-release/release/`curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt`/bin/linux/amd64/kubectl \

--- a/Google/Dockerfile
+++ b/Google/Dockerfile
@@ -15,6 +15,7 @@ RUN apk add --update --no-cache \
         gettext \
         make \
         jq \
+        git \
     && wget -q https://storage.googleapis.com/kubernetes-helm/helm-${HELM_VERSION}-linux-amd64.tar.gz -O - | tar -xzO linux-amd64/helm > /usr/local/bin/helm \
     && gcloud components install beta kubectl \
     && chmod +x /usr/local/bin/*


### PR DESCRIPTION
If you want to use external repositories in Kustomize (see https://kubectl.docs.kubernetes.io/references/kustomize/resource/) you need to have git.