### PR TITLE
Update Helm to v3 and Alpine to 3.12

### DIFF
--- a/Amazon/Dockerfile
+++ b/Amazon/Dockerfile
@@ -1,8 +1,8 @@
-FROM alpine:3.10
+FROM alpine:3.12
 
 # Note: Latest version of helm may be found at:
 # https://github.com/kubernetes/helm/releases
-ENV HELM_VERSION="v2.16.10"
+ENV HELM_VERSION="v3.4.2"
 
 # Copy over the connection helper script
 COPY connect-kubernetes.sh /usr/local/bin/connect-kubernetes
@@ -13,6 +13,7 @@ RUN apk add --update --no-cache \
         curl \
         docker \
         gettext \
+        git \
         groff \
         make \
         jq \
@@ -20,8 +21,7 @@ RUN apk add --update --no-cache \
         python3 \
         python3-dev \
         py3-pip \
-        git \
-    && wget -q https://storage.googleapis.com/kubernetes-helm/helm-${HELM_VERSION}-linux-amd64.tar.gz -O - | tar -xzO linux-amd64/helm > /usr/local/bin/helm \
+    && wget -q https://get.helm.sh/helm-${HELM_VERSION}-linux-amd64.tar.gz -O - | tar -xzO linux-amd64/helm > /usr/local/bin/helm \
     && pip3 install awscli --upgrade \
     && curl -LO https://storage.googleapis.com/kubernetes-release/release/`curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt`/bin/linux/amd64/kubectl \
     && mv ./kubectl /usr/local/bin/kubectl \

--- a/Azure/Dockerfile
+++ b/Azure/Dockerfile
@@ -1,8 +1,8 @@
-FROM alpine:3.10
+FROM alpine:3.12
 
 # Note: Latest version of helm may be found at:
 # https://github.com/kubernetes/helm/releases
-ENV HELM_VERSION="v2.16.10"
+ENV HELM_VERSION="v3.4.2"
 
 # Copy over the connection helper script
 COPY connect-kubernetes.sh /usr/local/bin/connect-kubernetes
@@ -14,6 +14,7 @@ RUN apk add --update --no-cache \
         docker \
         gcc \
         gettext \
+        git \
         make \
         musl-dev \
         jq \
@@ -22,8 +23,7 @@ RUN apk add --update --no-cache \
         python3 \
         python3-dev \
         py3-pip \
-        git \
-    && wget -q https://storage.googleapis.com/kubernetes-helm/helm-${HELM_VERSION}-linux-amd64.tar.gz -O - | tar -xzO linux-amd64/helm > /usr/local/bin/helm \
+    && wget -q https://get.helm.sh/helm-${HELM_VERSION}-linux-amd64.tar.gz -O - | tar -xzO linux-amd64/helm > /usr/local/bin/helm \
     && pip3 install azure-cli --upgrade \
     && apk del gcc libffi-dev openssl-dev \
     && ln -s /usr/bin/python3 /usr/local/bin/python \

--- a/DigitalOcean/Dockerfile
+++ b/DigitalOcean/Dockerfile
@@ -1,8 +1,8 @@
-FROM alpine:3.10
+FROM alpine:3.12
 
 # Note: Latest version of helm may be found at:
 # https://github.com/kubernetes/helm/releases
-ENV HELM_VERSION="v2.16.10"
+ENV HELM_VERSION="v3.4.2"
 
 # Copy over the connection helper script
 COPY connect-kubernetes.sh /usr/local/bin/connect-kubernetes
@@ -13,10 +13,10 @@ RUN apk add --update --no-cache \
         curl \
         docker \
         gettext \
+        git \
         make \
         jq \
-        git \
-    && wget -q https://storage.googleapis.com/kubernetes-helm/helm-${HELM_VERSION}-linux-amd64.tar.gz -O - | tar -xzO linux-amd64/helm > /usr/local/bin/helm \
+    && wget -q https://get.helm.sh/helm-${HELM_VERSION}-linux-amd64.tar.gz -O - | tar -xzO linux-amd64/helm > /usr/local/bin/helm \
     && wget -q https://github.com/digitalocean/doctl/releases/download/v1.35.0/doctl-1.35.0-linux-amd64.tar.gz -O - | tar -xzO doctl > /usr/local/bin/doctl \
     && curl -LO https://storage.googleapis.com/kubernetes-release/release/`curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt`/bin/linux/amd64/kubectl \
     && mv ./kubectl /usr/local/bin/kubectl \

--- a/Google/Dockerfile
+++ b/Google/Dockerfile
@@ -2,7 +2,7 @@ FROM google/cloud-sdk:alpine
 
 # Note: Latest version of helm may be found at:
 # https://github.com/kubernetes/helm/releases
-ENV HELM_VERSION="v2.16.10"
+ENV HELM_VERSION="v3.4.2"
 
 # Copy over the connection helper script
 COPY connect-kubernetes.sh /usr/local/bin/connect-kubernetes
@@ -13,9 +13,9 @@ RUN apk add --update --no-cache \
         curl \
         docker \
         gettext \
+        git \
         make \
         jq \
-        git \
-    && wget -q https://storage.googleapis.com/kubernetes-helm/helm-${HELM_VERSION}-linux-amd64.tar.gz -O - | tar -xzO linux-amd64/helm > /usr/local/bin/helm \
+    && wget -q https://get.helm.sh/helm-${HELM_VERSION}-linux-amd64.tar.gz -O - | tar -xzO linux-amd64/helm > /usr/local/bin/helm \
     && gcloud components install beta kubectl \
     && chmod +x /usr/local/bin/*

--- a/Makefile
+++ b/Makefile
@@ -80,7 +80,7 @@ do-test-amazon:
 	@echo "=== Test Amazon Kubernetes toolbox ==="
 	@echo ""
 	docker run --rm enrise/kube-toolbox:amazon connect-kubernetes | grep -q Usage
-	docker run --rm enrise/kube-toolbox:amazon helm version 2>&1 | grep -q version.Version
+	docker run --rm enrise/kube-toolbox:amazon helm version 2>&1 | grep -q version.BuildInfo
 	docker run --rm enrise/kube-toolbox:amazon kubectl version 2>&1 | grep -q version.Info
 	docker run --rm enrise/kube-toolbox:amazon aws --version | grep -q aws-cli
 
@@ -89,7 +89,7 @@ do-test-azure:
 	@echo "=== Test Azure Kubernetes toolbox ==="
 	@echo ""
 	docker run --rm enrise/kube-toolbox:azure connect-kubernetes | grep -q Usage
-	docker run --rm enrise/kube-toolbox:azure helm version 2>&1 | grep -q version.Version
+	docker run --rm enrise/kube-toolbox:azure helm version 2>&1 | grep -q version.BuildInfo
 	docker run --rm enrise/kube-toolbox:azure kubectl version 2>&1 | grep -q version.Info
 	docker run --rm enrise/kube-toolbox:azure az --version | grep -q azure-cli
 
@@ -98,7 +98,7 @@ do-test-google:
 	@echo "=== Test Google Kubernetes toolbox ==="
 	@echo ""
 	docker run --rm enrise/kube-toolbox:google connect-kubernetes | grep -q Usage
-	docker run --rm enrise/kube-toolbox:google helm version 2>&1 | grep -q version.Version
+	docker run --rm enrise/kube-toolbox:google helm version 2>&1 | grep -q version.BuildInfo
 	docker run --rm enrise/kube-toolbox:google kubectl version 2>&1 | grep -q version.Info
 	docker run --rm enrise/kube-toolbox:google gcloud --version 2>&1 | grep -q "Google Cloud SDK"
 
@@ -107,7 +107,7 @@ do-test-digital-ocean:
 	@echo "=== Test Digital Ocean Kubernetes toolbox ==="
 	@echo ""
 	docker run --rm enrise/kube-toolbox:digital-ocean connect-kubernetes | grep -q Usage
-	docker run --rm enrise/kube-toolbox:digital-ocean helm version 2>&1 | grep -q version.Version
+	docker run --rm enrise/kube-toolbox:digital-ocean helm version 2>&1 | grep -q version.BuildInfo
 	docker run --rm enrise/kube-toolbox:digital-ocean kubectl version 2>&1 | grep -q version.Info
 	docker run --rm enrise/kube-toolbox:digital-ocean doctl version 2>&1 | grep -q "doctl version"
 


### PR DESCRIPTION
# What

Since [the Helm 2 stable repo is deprecated](https://helm.sh/blog/helm-v2-deprecation-timeline/), we should move on to Helm 3. This PR takes care of that. It also bumps Alpine to the latest stable, which is 3.12 at the time of writing.