### PR TITLE
Add gke-gcloud-auth-plugin, bump helm version

### DIFF
--- a/Amazon/Dockerfile
+++ b/Amazon/Dockerfile
@@ -2,7 +2,7 @@ FROM alpine:3.12
 
 # Note: Latest version of helm may be found at:
 # https://github.com/kubernetes/helm/releases
-ENV HELM_VERSION="v3.4.2"
+ENV HELM_VERSION="v3.9.0"
 
 # Copy over the connection helper script
 COPY connect-kubernetes.sh /usr/local/bin/connect-kubernetes

--- a/Azure/Dockerfile
+++ b/Azure/Dockerfile
@@ -2,7 +2,7 @@ FROM alpine:3.12
 
 # Note: Latest version of helm may be found at:
 # https://github.com/kubernetes/helm/releases
-ENV HELM_VERSION="v3.4.2"
+ENV HELM_VERSION="v3.9.0"
 
 # Copy over the connection helper script
 COPY connect-kubernetes.sh /usr/local/bin/connect-kubernetes

--- a/DigitalOcean/Dockerfile
+++ b/DigitalOcean/Dockerfile
@@ -2,7 +2,7 @@ FROM alpine:3.12
 
 # Note: Latest version of helm may be found at:
 # https://github.com/kubernetes/helm/releases
-ENV HELM_VERSION="v3.4.2"
+ENV HELM_VERSION="v3.9.0"
 
 # Copy over the connection helper script
 COPY connect-kubernetes.sh /usr/local/bin/connect-kubernetes

--- a/Google/Dockerfile
+++ b/Google/Dockerfile
@@ -2,7 +2,7 @@ FROM google/cloud-sdk:alpine
 
 # Note: Latest version of helm may be found at:
 # https://github.com/kubernetes/helm/releases
-ENV HELM_VERSION="v3.4.2"
+ENV HELM_VERSION="v3.9.0"
 
 # Copy over the connection helper script
 COPY connect-kubernetes.sh /usr/local/bin/connect-kubernetes
@@ -17,5 +17,7 @@ RUN apk add --update --no-cache \
         make \
         jq \
     && wget -q https://get.helm.sh/helm-${HELM_VERSION}-linux-amd64.tar.gz -O - | tar -xzO linux-amd64/helm > /usr/local/bin/helm \
-    && gcloud components install beta kubectl \
+    && gcloud components install beta gke-gcloud-auth-plugin kubectl \
     && chmod +x /usr/local/bin/*
+
+ENV USE_GKE_GCLOUD_AUTH_PLUGIN=True


### PR DESCRIPTION
The auth provider of gke will switch in kubectl v1.25 
see https://cloud.google.com/blog/products/containers-kubernetes/kubectl-auth-changes-in-gke for more information