### PR TITLE
Upgrade to Alpine Linux 3.22 and Helm 3.18.3

### DIFF
--- a/Amazon/Dockerfile
+++ b/Amazon/Dockerfile
@@ -1,28 +1,28 @@
-FROM alpine:3.18
+FROM alpine:3.22
 
 # Note: Latest version of helm may be found at:
 # https://github.com/kubernetes/helm/releases
-ENV HELM_VERSION="v3.13.1"
+ENV HELM_VERSION="v3.18.3"
 
 # Copy over the connection helper script
 COPY connect-kubernetes.sh /usr/local/bin/connect-kubernetes
 
 # Install tools
 RUN apk add --update --no-cache \
-        bash \
-        curl \
-        docker \
-        gettext \
-        git \
-        groff \
-        make \
-        jq \
-        less \
-        python3 \
-        python3-dev \
-        py3-pip \
+    bash \
+    curl \
+    docker \
+    gettext \
+    git \
+    groff \
+    make \
+    jq \
+    less \
+    python3 \
+    python3-dev \
+    py3-pip \
     && wget -q https://get.helm.sh/helm-${HELM_VERSION}-linux-amd64.tar.gz -O - | tar -xzO linux-amd64/helm > /usr/local/bin/helm \
-    && pip3 install awscli --upgrade \
+    && pip3 install --break-system-packages awscli --upgrade \
     && curl -LO https://storage.googleapis.com/kubernetes-release/release/`curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt`/bin/linux/amd64/kubectl \
     && mv ./kubectl /usr/local/bin/kubectl \
     && chmod +x /usr/local/bin/*

--- a/Azure/Dockerfile
+++ b/Azure/Dockerfile
@@ -1,30 +1,30 @@
-FROM alpine:3.18
+FROM alpine:3.22
 
 # Note: Latest version of helm may be found at:
 # https://github.com/kubernetes/helm/releases
-ENV HELM_VERSION="v3.13.1"
+ENV HELM_VERSION="v3.18.3"
 
 # Copy over the connection helper script
 COPY connect-kubernetes.sh /usr/local/bin/connect-kubernetes
 
 # Install tools
 RUN apk add --update --no-cache \
-        bash \
-        curl \
-        docker \
-        gcc \
-        gettext \
-        git \
-        make \
-        musl-dev \
-        jq \
-        libffi-dev \
-        openssl-dev \
-        python3 \
-        python3-dev \
-        py3-pip \
+    bash \
+    curl \
+    docker \
+    gcc \
+    gettext \
+    git \
+    make \
+    musl-dev \
+    jq \
+    libffi-dev \
+    openssl-dev \
+    python3 \
+    python3-dev \
+    py3-pip \
     && wget -q https://get.helm.sh/helm-${HELM_VERSION}-linux-amd64.tar.gz -O - | tar -xzO linux-amd64/helm > /usr/local/bin/helm \
-    && pip3 install azure-cli --upgrade \
+    && pip3 install --break-system-packages azure-cli --upgrade \
     && apk del gcc libffi-dev openssl-dev \
     && ln -s /usr/bin/python3 /usr/local/bin/python \
     && az aks install-cli \

--- a/DigitalOcean/Dockerfile
+++ b/DigitalOcean/Dockerfile
@@ -1,21 +1,21 @@
-FROM alpine:3.18
+FROM alpine:3.22
 
 # Note: Latest version of helm may be found at:
 # https://github.com/kubernetes/helm/releases
-ENV HELM_VERSION="v3.13.1"
+ENV HELM_VERSION="v3.18.3"
 
 # Copy over the connection helper script
 COPY connect-kubernetes.sh /usr/local/bin/connect-kubernetes
 
 # Install tools
 RUN apk add --update --no-cache \
-        bash \
-        curl \
-        docker \
-        gettext \
-        git \
-        make \
-        jq \
+    bash \
+    curl \
+    docker \
+    gettext \
+    git \
+    make \
+    jq \
     && wget -q https://get.helm.sh/helm-${HELM_VERSION}-linux-amd64.tar.gz -O - | tar -xzO linux-amd64/helm > /usr/local/bin/helm \
     && wget -q https://github.com/digitalocean/doctl/releases/download/v1.100.0/doctl-1.100.0-linux-amd64.tar.gz -O - | tar -xzO doctl > /usr/local/bin/doctl \
     && curl -LO https://storage.googleapis.com/kubernetes-release/release/`curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt`/bin/linux/amd64/kubectl \

--- a/Google/Dockerfile
+++ b/Google/Dockerfile
@@ -2,20 +2,20 @@ FROM google/cloud-sdk:alpine
 
 # Note: Latest version of helm may be found at:
 # https://github.com/kubernetes/helm/releases
-ENV HELM_VERSION="v3.13.1"
+ENV HELM_VERSION="v3.18.3"
 
 # Copy over the connection helper script
 COPY connect-kubernetes.sh /usr/local/bin/connect-kubernetes
 
 # Install tools
 RUN apk add --update --no-cache \
-        bash \
-        curl \
-        docker \
-        gettext \
-        git \
-        make \
-        jq \
+    bash \
+    curl \
+    docker \
+    gettext \
+    git \
+    make \
+    jq \
     && wget -q https://get.helm.sh/helm-${HELM_VERSION}-linux-amd64.tar.gz -O - | tar -xzO linux-amd64/helm > /usr/local/bin/helm \
     && gcloud components install gke-gcloud-auth-plugin kubectl \
     && chmod +x /usr/local/bin/*


### PR DESCRIPTION
## What has been done
- Upgrade to Alpine Linux 3.22
- Upgrade to Helm 3.18.3
- Added `--break-system-packages` because Azure and AWS CLI are not available as package in the Alpine repo and we only need Python for these packages, so should be safe to do.