### PR TITLE
Set up dependabot to automate the updates via PR's

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,16 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "docker"
+    directories:
+      - "/*"
+    schedule:
+      interval: "weekly"
+    groups:
+      docker-updates:
+        update-types:
+          - "patch"
+          - "minor"


### PR DESCRIPTION
* This will allow Dependabot to create PR's when an update for the Docker images or GitHub actions is found.
* Minor & patch updates are grouped in one PR, majors in a separate PR