### PR TITLE
Only login when it's a commit to master to fix failing pipelines on PR's

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,7 +1,7 @@
 name: Build Docker images
 on:
   push:
-    branches: [ master ]
+    branches: [master]
   pull_request:
   schedule:
     - cron: "0 3 * * 1" # Run every Monday at 3:00
@@ -15,6 +15,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
       - name: Login to Docker Hub Container Registry
+        if: github.ref == 'refs/heads/master'
         uses: docker/login-action@v2
         with:
           username: ${{ secrets.DOCKER_HUB_USERNAME }}


### PR DESCRIPTION
## What has been done
- Only login when it's a commit to master to fix failing pipelines on PR's
 